### PR TITLE
Fix feature flaws for duplication detection and case sensitivity

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddArticleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddArticleCommandParser.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.articlecommands.AddArticleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.article.Article;
+import seedu.address.model.article.Article.Status;
 import seedu.address.model.article.Author;
 import seedu.address.model.article.Outlet;
 import seedu.address.model.article.PublicationDate;
@@ -49,7 +50,7 @@ public class AddArticleCommandParser implements Parser<AddArticleCommand> {
         Set<Outlet> outletList = ParserUtil.parseOutlets(argMultimap.getAllValues(PREFIX_OUTLET));
         PublicationDate publicationDate = ParserUtil.parsePublicationDate(argMultimap.getValue(PREFIX_PUBLICATION_DATE)
                 .get());
-        Article.Status status = (Article.Status) ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
+        Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
 
         Article article = new Article(title, authorList, sourceList, tagList, outletList, publicationDate, status);
 

--- a/src/main/java/seedu/address/logic/parser/EditArticleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditArticleCommandParser.java
@@ -19,7 +19,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.articlecommands.EditArticleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.article.Article;
 import seedu.address.model.article.Author;
 import seedu.address.model.article.Outlet;
 import seedu.address.model.article.Source;
@@ -62,7 +61,7 @@ public class EditArticleCommandParser implements Parser<EditArticleCommand> {
                     .getValue(PREFIX_PUBLICATION_DATE).get()));
         }
         if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
-            editArticleDescriptor.setStatus((Article.Status) ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS)
+            editArticleDescriptor.setStatus(ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS)
                     .get()));
         }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -257,7 +257,7 @@ public class ParserUtil {
     public static Status parseStatus(String status) throws ParseException {
         requireNonNull(status);
         String trimmedStatus = status.trim();
-        switch (trimmedStatus) {
+        switch (trimmedStatus.toUpperCase()) {
         case "DRAFT":
             return DRAFT;
         case "PUBLISHED":
@@ -265,7 +265,7 @@ public class ParserUtil {
         case "ARCHIVED":
             return ARCHIVED;
         default:
-            throw new ParseException("Invalid status");
+            throw new ParseException("Invalid status provided. Please provide either draft, published or archived.");
         }
     }
 }

--- a/src/main/java/seedu/address/model/article/Title.java
+++ b/src/main/java/seedu/address/model/article/Title.java
@@ -43,6 +43,18 @@ public class Title implements Comparable<Title> {
         return this.fullTitle.compareTo(other.fullTitle);
     }
 
+    private boolean areSameTitles(String[] title, String[] otherTitle) {
+        if (title.length != otherTitle.length) {
+            return false;
+        }
+        for (int i = 0; i < title.length; i++) {
+            if (!title[i].equalsIgnoreCase(otherTitle[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -54,9 +66,15 @@ public class Title implements Comparable<Title> {
         }
 
         Title otherTitle = (Title) other;
-        return otherTitle.fullTitle.equals(this.fullTitle);
+        String[] splitTitle = fullTitle.split("\\s+");
+        String[] splitOtherTitle = otherTitle.fullTitle.split("\\s+");
+
+        return areSameTitles(splitTitle, splitOtherTitle);
     }
 
+    // It is safe to implement hashCode() this way because there are already precautions
+    // in place to ensure that no two Title instances can be kept in articles in the Article Book
+    // that are equal and yet have different hashcode values.
     @Override
     public int hashCode() {
         return fullTitle.hashCode();

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -49,6 +49,18 @@ public class Name implements Comparable<Name> {
         return this.fullName.compareTo(other.fullName);
     }
 
+    private boolean areSameNames(String[] name, String[] otherName) {
+        if (name.length != otherName.length) {
+            return false;
+        }
+        for (int i = 0; i < name.length; i++) {
+            if (!name[i].equalsIgnoreCase(otherName[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -61,9 +73,15 @@ public class Name implements Comparable<Name> {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        String[] splitName = fullName.split("\\s+");
+        String[] splitOtherName = otherName.fullName.split("\\s+");
+
+        return areSameNames(splitName, splitOtherName);
     }
 
+    // It is safe to implement hashCode() this way because there are already precautions
+    // in place to ensure that no two Name instances can be kept in persons in the Address Book
+    // that are equal and yet have different hashcode values.
     @Override
     public int hashCode() {
         return fullName.hashCode();

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -37,18 +37,18 @@ public class PersonTest {
                 .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
+        // name differs in case, all other attributes same -> returns true
+        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        assertTrue(BOB.isSamePerson(editedBob));
+
+        // name has trailing spaces, all other attributes same -> returns true
+        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
+        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
+        assertTrue(BOB.isSamePerson(editedBob));
+
         // different name, all other attributes same -> returns false
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
-
-        // name differs in case, all other attributes same -> returns false
-        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
-
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
     }
 
     @Test


### PR DESCRIPTION
* Let's make Name and Title comparisons non case-sensitive and also by ignoring all whitespaces surrounding each word.

* By doing so, we prevent the user from accidentally entering into the app, two Persons or Articles with the same Name or Title as they may have forgotten they had entered such data before.

* Let's make our status field supplied by the user case-insensitive, so that the user does not find it inconvenient when typing in the status of an article.

We will do so by:

* Editing the `parseStatus` method in the `ParserUtil` class to accept all statuses provided by the user without case-sensitivity constraints.

Closes #95 