### PR TITLE
Fix incorrect editing of hidden persons attribute

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -67,7 +67,8 @@ public class MainApp extends Application {
         storage = new StorageManager(addressBookStorage, userPrefsStorage, articleBookStorage);
 
         model = initModelManager(storage, userPrefs);
-
+        storage.saveAddressBook(model.getAddressBook());
+        storage.saveArticleBook(model.getArticleBook());
         logic = new LogicManager(model, storage);
 
         ui = new UiManager(logic);

--- a/src/main/java/seedu/address/logic/commands/articlecommands/EditArticleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/articlecommands/EditArticleCommand.java
@@ -127,7 +127,6 @@ public class EditArticleCommand extends ArticleCommand {
 
         Article editedArticle = new Article(title, authors, sources, tags,
                 outlets, publicationDate, status, link); // Include all article attributes here.
-        editedArticle.setPersons(articleToEdit.getPersons());
         return editedArticle;
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -179,6 +179,7 @@ public class ModelManager implements Model {
     public void setArticle(Article target, Article editedArticle) {
         requireAllNonNull(target, editedArticle);
 
+        editedArticle.setPersons(editedArticle.getMatchingPersonsList(addressBook.getPersonList()));
         articleBook.setArticle(target, editedArticle);
     }
 

--- a/src/main/java/seedu/address/model/article/Article.java
+++ b/src/main/java/seedu/address/model/article/Article.java
@@ -122,7 +122,30 @@ public class Article {
     }
 
     /**
-     * Sets the persons list of a edited article.
+     * Returns a list of persons that match the authors and sources of the article.
+     *
+     * @param persons a list of persons to compare against the article's authors and sources.
+     * @return a list of persons that match the authors and sources of the article.
+     */
+    public List<Person> getMatchingPersonsList(List<Person> persons) {
+        List<Person> matchingPersons = new ArrayList<>();
+        for (Person person : persons) {
+            for (Author author : authors) {
+                if (author.authorName.equals(person.getNameString())) {
+                    matchingPersons.add(person);
+                }
+            }
+            for (Source source : sources) {
+                if (source.sourceName.equals(person.getNameString())) {
+                    matchingPersons.add(person);
+                }
+            }
+        }
+        return matchingPersons;
+    }
+
+    /**
+     * Sets the persons list of an edited article.
      *
      * @param persons
      */


### PR DESCRIPTION
Added logic to correctly update the persons attribute of an article to fit the new edited author and sources attributes.

Added logic to save the sample data as json files on startup.

Did not add a fix for incorrect editing of duplicate named articles.

Note that this fix may cause slow down at extremely large list sizes (there is a fair amount of recursion involved due to trying to maintain OOP principles).

Fixes #155
Fixes #189 
Fixes #211