### PR TITLE
Fix bug when parsing article commands

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -49,7 +49,7 @@ public class AddressBookParser {
         final String arguments = matcher.group("arguments");
 
         if (arguments.trim().endsWith("-a") || arguments.trim().startsWith("-a ")) {
-            return ArticleBookParser.parseCommand(commandWord + arguments.substring(3));
+            return ArticleBookParser.parseCommand(commandWord + arguments.trim().substring(2));
         }
 
         // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)


### PR DESCRIPTION
* This bug was flagged by a tester in the PE-D and after some manual testing, it was discovered to not only apply to the `list -a` command, but also all article commands in general.

* The bug can be categorized as a functional bug as it was already mentioned in the UG that "extra whitespaces in the `list -a` command was handled by the program before the feature freeze.

* The bug only occurs when there are 2/3 whitespaces after the command word and before the `-a` flag.

* The change was made to line 52 of the `AddressBookParser` class.

Closes #163 